### PR TITLE
resolves datatypevoid/vulgar#5 ; lock down angular2-material and ngrx dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "@ngrx/store": "^1.3.3",
+    "@ngrx/store": "1.3.3",
     "angular2": "2.0.0-beta.12",
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.14.2",
@@ -81,14 +81,14 @@
     "zone.js": "0.6.6"
   },
   "devDependencies": {
-    "@angular2-material/button": "^2.0.0-alpha.1",
-    "@angular2-material/card": "^2.0.0-alpha.1",
-    "@angular2-material/checkbox": "^2.0.0-alpha.1",
-    "@angular2-material/core": "^2.0.0-alpha.1",
-    "@angular2-material/progress-circle": "^2.0.0-alpha.1",
-    "@angular2-material/radio": "^2.0.0-alpha.1",
-    "@angular2-material/sidenav": "^2.0.0-alpha.1",
-    "@angular2-material/toolbar": "^2.0.0-alpha.1",
+    "@angular2-material/button": "2.0.0-alpha.1",
+    "@angular2-material/card": "2.0.0-alpha.1",
+    "@angular2-material/checkbox": "2.0.0-alpha.1",
+    "@angular2-material/core": "2.0.0-alpha.1",
+    "@angular2-material/progress-circle": "2.0.0-alpha.1",
+    "@angular2-material/radio": "2.0.0-alpha.1",
+    "@angular2-material/sidenav": "2.0.0-alpha.1",
+    "@angular2-material/toolbar": "2.0.0-alpha.1",
     "angular2-hmr": "~0.5.1",
     "awesome-typescript-loader": "~0.16.2",
     "babel-cli": "^6.4.5",


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: locking down "angular2-material/*" to download exact "2.0.0-alpha.1" version, because the latest (...alpha.4) will require angular-rc0 as  peer dependencies and some paths and components have been moved around. Same thing for "@ngrx/store"
- **What is the current behavior?** (You can also link to an open issue here)
Fixes https://github.com/datatypevoid/vulgar/issues/5
- **What is the new behavior (if this is a feature change)?**

- **Other information**:
This is a temporary solution. Entire project should be updated to use latest version (rc1?) of angular 2 and the new paths for imports.
