### PR TITLE
feat: enable PathLocationStrategy

### DIFF
--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -24,7 +24,7 @@ export function main(initialHmrState?: any): Promise<any> {
     ...DIRECTIVES,
     ...PIPES,
     ...APP_PROVIDERS,
-    ...APP_STORES,
+    ...APP_STORES
   ])
   .catch(err => console.error(err));
 }

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -1,11 +1,6 @@
 //# Providers provided by Angular
 import {bootstrap} from '@angular/platform-browser-dynamic';
 
-//# Required Angular providers to enable PathLocationStrategy
-import {provide} from '@angular/core';
-import {APP_BASE_HREF} from '@angular/common';
-import {ROUTER_PROVIDERS} from '@angular/router';
-
 //## Platform and Environment
 //
 //** our providers/directives/pipes **
@@ -19,7 +14,6 @@ import {App, APP_PROVIDERS, APP_STORES} from './app';
 
 // Bootstrap our Angular app with a top level component `App` and inject
 // our Services and Providers into Angular's dependency injection
-// NOTE: ROUTER_PROVIDERS and provide lines for PathLocationStrategy
 
 export function main(initialHmrState?: any): Promise<any> {
 
@@ -31,8 +25,6 @@ export function main(initialHmrState?: any): Promise<any> {
     ...PIPES,
     ...APP_PROVIDERS,
     ...APP_STORES,
-    ROUTER_PROVIDERS,
-    provide(APP_BASE_HREF, {useValue: '/'})
   ])
   .catch(err => console.error(err));
 }

--- a/src/main.browser.ts
+++ b/src/main.browser.ts
@@ -1,6 +1,11 @@
 //# Providers provided by Angular
 import {bootstrap} from '@angular/platform-browser-dynamic';
 
+//# Required Angular providers to enable PathLocationStrategy
+import {provide} from '@angular/core';
+import {APP_BASE_HREF} from '@angular/common';
+import {ROUTER_PROVIDERS} from '@angular/router';
+
 //## Platform and Environment
 //
 //** our providers/directives/pipes **
@@ -14,6 +19,7 @@ import {App, APP_PROVIDERS, APP_STORES} from './app';
 
 // Bootstrap our Angular app with a top level component `App` and inject
 // our Services and Providers into Angular's dependency injection
+// NOTE: ROUTER_PROVIDERS and provide lines for PathLocationStrategy
 
 export function main(initialHmrState?: any): Promise<any> {
 
@@ -24,7 +30,9 @@ export function main(initialHmrState?: any): Promise<any> {
     ...DIRECTIVES,
     ...PIPES,
     ...APP_PROVIDERS,
-    ...APP_STORES
+    ...APP_STORES,
+    ROUTER_PROVIDERS,
+    provide(APP_BASE_HREF, {useValue: '/'})
   ])
   .catch(err => console.error(err));
 }

--- a/src/platform/browser/providers.ts
+++ b/src/platform/browser/providers.ts
@@ -18,6 +18,16 @@ import {ROUTER_PROVIDERS} from '@angular/router-deprecated';
 // TODO:(datatypevoid): replace with @angular2-material/all
 import {MATERIAL_PROVIDERS} from './angular2-material2'
 
+var config = require('../../../config/config.json');
+
+let configLocation: Object = {};
+
+if (config.LOC === 'path')
+  configLocation = {provide: LocationStrategy, useClass: PathLocationStrategy};
+
+else
+  configLocation = {provide: LocationStrategy, useClass: HashLocationStrategy};
+
 //# Application Providers/Directives/Pipes
 //
 //** providers/directives/pipes that only live in our browser environment **
@@ -26,7 +36,7 @@ export const APPLICATION_PROVIDERS = [
   ...HTTP_PROVIDERS,
   ...MATERIAL_PROVIDERS,
   ...ROUTER_PROVIDERS,
-  {provide: LocationStrategy, useClass: PathLocationStrategy }
+    configLocation
 ];
 
 export const PROVIDERS = [

--- a/src/platform/browser/providers.ts
+++ b/src/platform/browser/providers.ts
@@ -3,8 +3,7 @@
 //** These `providers` are available in any template **
 
 // Angular 2
-import {APP_BASE_HREF,
-        FORM_PROVIDERS,
+import {FORM_PROVIDERS,
         LocationStrategy,
         HashLocationStrategy,
         PathLocationStrategy} from '@angular/common';

--- a/src/platform/browser/providers.ts
+++ b/src/platform/browser/providers.ts
@@ -3,9 +3,11 @@
 //** These `providers` are available in any template **
 
 // Angular 2
-import {FORM_PROVIDERS,
+import {APP_BASE_HREF,
+        FORM_PROVIDERS,
         LocationStrategy,
-        HashLocationStrategy} from '@angular/common';
+        HashLocationStrategy,
+        PathLocationStrategy} from '@angular/common';
 
 // Angular 2 Http
 import {HTTP_PROVIDERS} from '@angular/http';
@@ -25,7 +27,7 @@ export const APPLICATION_PROVIDERS = [
   ...HTTP_PROVIDERS,
   ...MATERIAL_PROVIDERS,
   ...ROUTER_PROVIDERS,
-  {provide: LocationStrategy, useClass: HashLocationStrategy }
+  {provide: LocationStrategy, useClass: PathLocationStrategy }
 ];
 
 export const PROVIDERS = [


### PR DESCRIPTION
### Feature to enable PathLocationStrategy
- Currently a hash sign will always be in the URL as default
- New feature removes hash sign from URL
