### PR TITLE
Update user.model.ts

### DIFF
--- a/src/server/models/user.model.ts
+++ b/src/server/models/user.model.ts
@@ -26,7 +26,7 @@ export interface IUser {
     email: string;
   };
   role: string;
-  _id: any;
+  _id: mongodb.ObjectID;
 }
 
 export class User implements IUser {
@@ -36,7 +36,7 @@ export class User implements IUser {
     email: string;
   };
   role: string;
-  _id: any;
+  _id: mongodb.ObjectID;
 
   constructor(data: IUser, role: string) {
     this.local.username = data.local.username;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** 
Bug fix
- **What is the current behavior?**
Interface 'UserDocument' cannot simultaneously extend types 'User' and 'Document'.
  Named property '_id' of types 'User' and 'Document' are not identical.
- **What is the new behavior (if this is a feature change)?**
Error is fixed
- **Other information**:
The _id:any attribute needs to be changed to _id: mongodb.ObjectID;
